### PR TITLE
Added a method to force refresh without any check

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Refresh visible annotations as needed:
 
 This is typically done in `-mapView:regionDidChangeAnimated:`
 
-The refresh methods checks if the map is visible and if the viewport has significantly changed. In some specific cases, it might be useful to force a refresh without doing the checks. The method `-(void)refresh:(BOOL)animated force:(BOOL)force` of KPClusteringController with force = YES will do that. This method can become CPU heavy and should be used in specific cases.
+__Note:__  The refresh method checks if the map is visible and if the viewport has significantly changed. In some specific cases, it might be useful to force a refresh without doing the checks. The method `-(void)refresh:(BOOL)animated force:(BOOL)force` of KPClusteringController with force = YES will do that. This method can become CPU heavy and should be used in specific cases.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Refresh visible annotations as needed:
 
 This is typically done in `-mapView:regionDidChangeAnimated:`
 
+The refresh methods checks if the map is visible and if the viewport has significantly changed. In some specific cases, it might be useful to force a refresh without doing the checks. The method `-(void)refresh:(BOOL)animated force:(BOOL)force` of KPClusteringController with force = YES will do that. This method can become CPU heavy and should be used in specific cases.
+
 ## Configuration
 
 To configure the clustering algorithm, create an instance of KPGridClusteringAlgorithm and use it to instantiate a KPClusteringController:

--- a/src/KPClusteringController.h
+++ b/src/KPClusteringController.h
@@ -33,7 +33,24 @@
 - (id)initWithMapView:(MKMapView *)mapView;
 - (id)initWithMapView:(MKMapView *)mapView clusteringAlgorithm:(id<KPClusteringAlgorithm>)algorithm;
 - (void)setAnnotations:(NSArray *)annoations;
+
+/**
+ *  @DEPRECATED
+ *
+ *  @param animated whether the view refresh is animated or not
+ */
 - (void)refresh:(BOOL)animated;
+
+/**
+ *  Refreshes the map. The force flag allows the user to force a refresh even though the viewport has not
+ *  significantly moved or if the map is not displayed. For most cases, leave the force flag to NO, forcing 
+ *  a refresh can be CPU heavy.
+ *
+ *  @param animated whether the view refresh is animated or not
+ *  @param force    YES if you want to force a refresh without checking for viewport change or if the map
+ *                  is visible, else NO.
+ */
+-(void)refresh:(BOOL)animated force:(BOOL)force;
 
 @end
 

--- a/src/KPClusteringController.h
+++ b/src/KPClusteringController.h
@@ -35,16 +35,16 @@
 - (void)setAnnotations:(NSArray *)annoations;
 
 /**
- *  @DEPRECATED
+ *  Refreshes the map annotations. This will check if the map is visible and if the viewport has changed
  *
  *  @param animated whether the view refresh is animated or not
  */
 - (void)refresh:(BOOL)animated;
 
 /**
- *  Refreshes the map. The force flag allows the user to force a refresh even though the viewport has not
- *  significantly moved or if the map is not displayed. For most cases, leave the force flag to NO, forcing 
- *  a refresh can be CPU heavy.
+ *  Refreshes the map annotations. The force flag allows the user to force a refresh even though the viewport 
+ *  has not significantly moved or if the map is not displayed. For most cases, leave the force flag to NO, 
+ *  forcing a refresh can be CPU heavy.
  *
  *  @param animated whether the view refresh is animated or not
  *  @param force    YES if you want to force a refresh without checking for viewport change or if the map

--- a/src/KPClusteringController.m
+++ b/src/KPClusteringController.m
@@ -102,7 +102,6 @@ typedef NS_ENUM(NSInteger, KPClusteringControllerMapViewportChangeState) {
 }
 
 - (void)refresh:(BOOL)animated {
-    // For legacy purposes
     [self refresh:animated force:NO];
 }
 

--- a/src/KPClusteringController.m
+++ b/src/KPClusteringController.m
@@ -102,19 +102,37 @@ typedef NS_ENUM(NSInteger, KPClusteringControllerMapViewportChangeState) {
 }
 
 - (void)refresh:(BOOL)animated {
-    if (self.mapView.visibleMapRect.size.width == 0 ||
-        self.mapView.visibleMapRect.size.height == 0) {
-        return;
-    }
+    // For legacy purposes
+    [self refresh:animated force:NO];
+}
 
-    KPClusteringControllerMapViewportChangeState mapViewportChangeState = self.mapViewportChangeState;
 
-    if (mapViewportChangeState != KPClusteringControllerMapViewportNoChange) {
-        [self updateVisibleMapAnnotationsOnMapView:(animated && mapViewportChangeState != KPClusteringControllerMapViewportPan)];
-
+-(void)refresh:(BOOL)animated force:(BOOL)force {
+    // If force flag is enabled, don't do any validation with the viewport changes
+    if (force) {
+        [self updateVisibleMapAnnotationsOnMapView:animated];
+        
         self.lastRefreshedMapRect = self.mapView.visibleMapRect;
         self.lastRefreshedMapRegion = self.mapView.region;
+        // Else, check for significant panning or if the map is displayed
+    } else {
+        // Check if map is visible
+        if (self.mapView.visibleMapRect.size.width == 0 ||
+            self.mapView.visibleMapRect.size.height == 0) {
+            return;
+        }
+        
+        KPClusteringControllerMapViewportChangeState mapViewportChangeState = self.mapViewportChangeState;
+        
+        // Check for signficant viewport changes
+        if (mapViewportChangeState != KPClusteringControllerMapViewportNoChange) {
+            [self updateVisibleMapAnnotationsOnMapView:(animated && mapViewportChangeState != KPClusteringControllerMapViewportPan)];
+            
+            self.lastRefreshedMapRect = self.mapView.visibleMapRect;
+            self.lastRefreshedMapRegion = self.mapView.region;
+        }
     }
+
 }
 
 // only refresh if:


### PR DESCRIPTION
So I added a method to actually force a refresh for some specific cases. We had to use this in a project and I felt like it could be a good addition. This is somehow mentioned in issue #5 too. 

I left the old refresh method and simply declared it deprecated. It uses the new version anyway.

If the force flag is YES, I do no checks at all, even if the map is not visible. I clearly mentioned in the comments to use with care. We could actually make the refresh still check if the map is visible.

Let me know what you think.