### PR TITLE
Update KPClusteringController.m

### DIFF
--- a/src/KPClusteringController.m
+++ b/src/KPClusteringController.m
@@ -268,6 +268,8 @@ typedef NS_ENUM(NSInteger, KPClusteringControllerMapViewportChangeState) {
             if ([self.delegate respondsToSelector:@selector(clusteringControllerDidUpdateVisibleMapAnnotations:)]) {
                 [self.delegate clusteringControllerDidUpdateVisibleMapAnnotations:self];
             }
+            
+            dispatch_release(group);
         });
     }
 


### PR DESCRIPTION
Xcode 6.1.1 reported a leak on the dispatch_group_create call, doc says it should be released so I added a call in a place that seemed reasonable.  So far working, could there be other locations release is required? thanks