### PR TITLE
Fix NSException nullability warning

### DIFF
--- a/kingpin/KPGridClusteringAlgorithm.m
+++ b/kingpin/KPGridClusteringAlgorithm.m
@@ -146,8 +146,8 @@ static CGPoint CGPointFromNSValue(NSValue *value) {
     if (self.clusteringStrategy == KPGridClusteringAlgorithmStrategyTwoPhase &&
         CGSizeEqualToSize(self.annotationSize, CGSizeZero))
     {
-        [NSException raise:@"annotationSize must be set when using two phase strategy"
-                    format:nil];
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"annotationSize must be set when using two phase strategy"];
     }
 }
 


### PR DESCRIPTION
When building in Xcode 7, NSException requires a non-null `format` string