### PR TITLE
Added a minimal zoom change for refreshing the cluster

### DIFF
--- a/kingpin/KPClusteringController.h
+++ b/kingpin/KPClusteringController.h
@@ -27,6 +27,9 @@
 /// these are ignored if the delegate implements -clusteringController:performAnimations:withCompletionHandler:
 @property (assign, nonatomic) CGFloat animationDuration;
 
+/// override the minimum zoom needed to refresh the cluster
+@property (assign, nonatomic) CGFloat minimalZoomChange;
+
 #if TARGET_OS_IPHONE
 @property (assign, nonatomic) UIViewAnimationOptions animationOptions;
 #endif

--- a/kingpin/KPClusteringController.m
+++ b/kingpin/KPClusteringController.m
@@ -78,6 +78,7 @@ typedef NS_ENUM(NSInteger, KPClusteringControllerMapViewportChangeState) {
     self.lastRefreshedMapRegion = self.mapView.region;
 
     self.animationDuration = 0.5f;
+    self.minimalZoomChange = 0.1f;
 
 #if TARGET_OS_IPHONE
     self.animationOptions = UIViewAnimationOptionCurveEaseOut;
@@ -150,7 +151,7 @@ typedef NS_ENUM(NSInteger, KPClusteringControllerMapViewportChangeState) {
         return KPClusteringControllerMapViewportNoChange;
     }
 
-    if (fabs(self.lastRefreshedMapRect.size.width - self.mapView.visibleMapRect.size.width) > 0.1f) {
+    if (fabs(self.lastRefreshedMapRect.size.width - self.mapView.visibleMapRect.size.width) > self.minimalZoomChange) {
         return KPClusteringControllerMapViewportZoom;
     }
 


### PR DESCRIPTION
Sometimes the clustering is refreshing even if the zoom is almost invisible.
This cause the PopoverView to close, I needed to make it less sensitive.

Not sure if you need this PR, up to you :ok_hand: 